### PR TITLE
Implement mocked sentry mode UI

### DIFF
--- a/frontend/src/commonMain/kotlin/com/example/dashcam/DashcamViewModel.kt
+++ b/frontend/src/commonMain/kotlin/com/example/dashcam/DashcamViewModel.kt
@@ -1,17 +1,43 @@
 package com.example.dashcam
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 
-class DashcamViewModel(private val service: EventService) {
+/** View model coordinating history and sentry state. */
+class DashcamViewModel(
+    private val service: EventService,
+    private val sentryService: SentryService
+) {
     private val _events = MutableStateFlow<List<Event>>(emptyList())
     val events: StateFlow<List<Event>> = _events
 
+    val sentryEnabled: StateFlow<Boolean> = sentryService.isActive
+
+    private val scope = CoroutineScope(Dispatchers.Default)
+
     init {
+        scope.launch {
+            sentryService.events.collect { event ->
+                _events.value = _events.value + event
+            }
+        }
         refresh()
     }
 
     fun refresh() {
         _events.value = service.getEvents()
+    }
+
+    fun toggleSentry() {
+        if (sentryService.isActive.value) sentryService.stop() else sentryService.start()
+    }
+
+    fun stop() {
+        sentryService.stop()
+        (scope.coroutineContext[Job] as? Job)?.cancel()
     }
 }

--- a/frontend/src/commonMain/kotlin/com/example/dashcam/Event.kt
+++ b/frontend/src/commonMain/kotlin/com/example/dashcam/Event.kt
@@ -1,3 +1,10 @@
 package com.example.dashcam
 
-data class Event(val description: String)
+/** Types of events that can be detected while in sentry mode. */
+enum class EventType { Motion, Person, Vehicle, Collision, Audio }
+
+/**
+ * Representation of a sentry event. The [type] describes what was detected and
+ * [description] provides a user friendly message.
+ */
+data class Event(val type: EventType, val description: String)

--- a/frontend/src/commonMain/kotlin/com/example/dashcam/EventService.kt
+++ b/frontend/src/commonMain/kotlin/com/example/dashcam/EventService.kt
@@ -6,7 +6,7 @@ interface EventService {
 
 class LocalEventService : EventService {
     override fun getEvents(): List<Event> = listOf(
-        Event("Motion detected"),
-        Event("Camera started")
+        Event(EventType.Motion, "Motion detected"),
+        Event(EventType.Person, "Camera started")
     )
 }

--- a/frontend/src/commonMain/kotlin/com/example/dashcam/SentryService.kt
+++ b/frontend/src/commonMain/kotlin/com/example/dashcam/SentryService.kt
@@ -1,0 +1,15 @@
+package com.example.dashcam
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+
+/** Service responsible for monitoring the camera feed and emitting events. */
+interface SentryService {
+    /** True when sentry mode is active. */
+    val isActive: StateFlow<Boolean>
+    /** Stream of detected events. */
+    val events: Flow<Event>
+
+    fun start()
+    fun stop()
+}

--- a/frontend/src/commonMain/kotlin/com/example/dashcam/ui/screens/DashcamScreen.kt
+++ b/frontend/src/commonMain/kotlin/com/example/dashcam/ui/screens/DashcamScreen.kt
@@ -1,0 +1,41 @@
+package com.example.dashcam.ui.screens
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * Simple dashcam screen that mocks a recording session.
+ */
+@Composable
+fun DashcamScreen() {
+    var recording by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier.fillMaxSize().padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            if (recording) "Recording..." else "Ready to record",
+            style = MaterialTheme.typography.headlineMedium
+        )
+        Spacer(Modifier.height(16.dp))
+        Button(onClick = { recording = !recording }) {
+            Text(if (recording) "Stop" else "Start")
+        }
+    }
+}

--- a/frontend/src/commonMain/kotlin/com/example/dashcam/ui/screens/MainScreen.kt
+++ b/frontend/src/commonMain/kotlin/com/example/dashcam/ui/screens/MainScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.example.dashcam.DashcamViewModel
 import com.example.dashcam.ui.MainTab
@@ -51,8 +50,8 @@ fun MainScreen(tab: MainTab, onSelectTab: (MainTab) -> Unit, dashcamViewModel: D
     }) { inner ->
         Box(Modifier.fillMaxSize().padding(inner)) {
             when (tab) {
-                MainTab.Dashcam -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) { Text("Dashcam Mode") }
-                MainTab.Sentry -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) { Text("Sentry Mode") }
+                MainTab.Dashcam -> DashcamScreen()
+                MainTab.Sentry -> SentryScreen(dashcamViewModel)
                 MainTab.History -> HistoryScreen(dashcamViewModel)
                 MainTab.Settings -> SettingsScreen()
             }

--- a/frontend/src/commonMain/kotlin/com/example/dashcam/ui/screens/SentryScreen.kt
+++ b/frontend/src/commonMain/kotlin/com/example/dashcam/ui/screens/SentryScreen.kt
@@ -1,0 +1,45 @@
+package com.example.dashcam.ui.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.dashcam.DashcamViewModel
+
+/**
+ * Screen that allows sentry mode to be toggled and shows recent events.
+ */
+@Composable
+fun SentryScreen(viewModel: DashcamViewModel) {
+    val enabled = viewModel.sentryEnabled.collectAsState()
+    val events = viewModel.events.collectAsState()
+
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        Button(onClick = { viewModel.toggleSentry() }) {
+            Text(if (enabled.value) "Disable Sentry" else "Enable Sentry")
+        }
+        Spacer(Modifier.height(16.dp))
+        LazyColumn(modifier = Modifier.weight(1f)) {
+            items(events.value) { event ->
+                Card(modifier = Modifier.padding(vertical = 4.dp)) {
+                    Text(
+                        event.description,
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier.padding(16.dp)
+                    )
+                }
+            }
+        }
+    }
+}

--- a/frontend/src/commonTest/kotlin/com/example/dashcam/DashcamViewModelTest.kt
+++ b/frontend/src/commonTest/kotlin/com/example/dashcam/DashcamViewModelTest.kt
@@ -5,7 +5,12 @@ import io.kotest.matchers.collections.shouldHaveSize
 
 class DashcamViewModelTest : BehaviorSpec({
     Given("a view model using LocalEventService") {
-        val viewModel = DashcamViewModel(LocalEventService())
+        val viewModel = DashcamViewModel(LocalEventService(), object : SentryService {
+            override val isActive = kotlinx.coroutines.flow.MutableStateFlow(false)
+            override val events = kotlinx.coroutines.flow.emptyFlow<Event>()
+            override fun start() {}
+            override fun stop() {}
+        })
         When("refresh is called") {
             viewModel.refresh()
             Then("events from the service are exposed") {

--- a/frontend/src/jvmMain/kotlin/com/example/dashcam/Main.kt
+++ b/frontend/src/jvmMain/kotlin/com/example/dashcam/Main.kt
@@ -3,9 +3,10 @@ package com.example.dashcam
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import com.example.dashcam.ui.AppViewModel
+import com.example.dashcam.service.MockSentryService
 
 fun main() = application {
-    val dashcamViewModel = DashcamViewModel(LocalEventService())
+    val dashcamViewModel = DashcamViewModel(LocalEventService(), MockSentryService())
     val appViewModel = AppViewModel()
     Window(onCloseRequest = ::exitApplication, title = "Sentry Phone Dashcam") {
         DashcamApp(appViewModel, dashcamViewModel)

--- a/frontend/src/jvmMain/kotlin/com/example/dashcam/service/MockSentryService.kt
+++ b/frontend/src/jvmMain/kotlin/com/example/dashcam/service/MockSentryService.kt
@@ -1,0 +1,55 @@
+package com.example.dashcam.service
+
+import com.example.dashcam.Event
+import com.example.dashcam.EventType
+import com.example.dashcam.SentryService
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Mock implementation of [SentryService] used on the JVM. It simulates AI
+ * detections by emitting random events every few seconds.
+ */
+class MockSentryService : SentryService {
+    private val scope = CoroutineScope(Dispatchers.Default)
+    private val _isActive = MutableStateFlow(false)
+    override val isActive: StateFlow<Boolean> = _isActive
+
+    private val _events = MutableSharedFlow<Event>()
+    override val events: Flow<Event> = _events
+
+    private var job: Job? = null
+
+    override fun start() {
+        if (_isActive.value) return
+        _isActive.value = true
+        job = scope.launch {
+            val types = EventType.values()
+            while (_isActive.value) {
+                delay(3000)
+                val type = types.random()
+                val desc = when (type) {
+                    EventType.Motion -> "Motion detected"
+                    EventType.Person -> "Person detected"
+                    EventType.Vehicle -> "Vehicle detected"
+                    EventType.Collision -> "Possible collision"
+                    EventType.Audio -> "Excessive audio detected"
+                }
+                _events.emit(Event(type, desc))
+            }
+        }
+    }
+
+    override fun stop() {
+        _isActive.value = false
+        job?.cancel()
+        job = null
+    }
+}

--- a/frontend/src/jvmTest/kotlin/com/example/dashcam/ui/screens/HistoryScreenTest.kt
+++ b/frontend/src/jvmTest/kotlin/com/example/dashcam/ui/screens/HistoryScreenTest.kt
@@ -5,11 +5,12 @@ import androidx.compose.ui.test.onNodeWithText
 import io.kotest.core.spec.style.BehaviorSpec
 import com.example.dashcam.DashcamViewModel
 import com.example.dashcam.LocalEventService
+import com.example.dashcam.service.MockSentryService
 
 class HistoryScreenTest : BehaviorSpec({
     val rule = createComposeRule()
     Given("the history screen") {
-        val vm = DashcamViewModel(LocalEventService())
+        val vm = DashcamViewModel(LocalEventService(), MockSentryService())
         rule.setContent { HistoryScreen(vm) }
         Then("events are displayed") {
             rule.onNodeWithText("Motion detected").assertExists()


### PR DESCRIPTION
## Summary
- extend `Event` with event types
- introduce `SentryService` and a `MockSentryService`
- update `DashcamViewModel` to control sentry mode
- add composable screens for Dashcam and Sentry
- wire screens into `MainScreen`
- adjust tests and main entry point

## Testing
- `./gradlew frontend:jvmTest --console plain`

------
https://chatgpt.com/codex/tasks/task_e_684699b12538832f9d8e0c87022c088e