### PR TITLE
Implement permissions screen and Android service

### DIFF
--- a/frontend/build.gradle.kts
+++ b/frontend/build.gradle.kts
@@ -1,9 +1,11 @@
 plugins {
     kotlin("multiplatform") version "1.9.10"
     id("org.jetbrains.compose") version "1.5.11"
+    id("com.android.library") version "8.2.0"
 }
 
 kotlin {
+    android()
     jvm {
         compilations.all {
             kotlinOptions.jvmTarget = "17"
@@ -29,11 +31,35 @@ kotlin {
             }
         }
         val jvmMain by getting
+        val androidMain by getting {
+            dependencies {
+                implementation("org.opencv:opencv-android:4.9.0")
+                implementation("androidx.core:core-ktx:1.12.0")
+                implementation("androidx.camera:camera-core:1.3.2")
+                implementation("androidx.camera:camera-camera2:1.3.2")
+                implementation("androidx.camera:camera-lifecycle:1.3.2")
+                implementation("androidx.camera:camera-view:1.3.2")
+            }
+        }
         val jvmTest by getting {
             dependencies {
                 implementation("org.jetbrains.compose.ui:ui-test-junit4:1.5.11")
             }
         }
+    }
+}
+
+android {
+    namespace = "com.example.dashcam"
+    compileSdk = 33
+
+    defaultConfig {
+        minSdk = 26
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 }
 

--- a/frontend/src/androidMain/AndroidManifest.xml
+++ b/frontend/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,12 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.dashcam">
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+
+    <application>
+        <service
+            android:name="com.example.dashcam.service.SentryMonitoringService"
+            android:exported="false"
+            android:foregroundServiceType="camera" />
+    </application>
+</manifest>

--- a/frontend/src/androidMain/kotlin/com/example/dashcam/service/AndroidSentryService.kt
+++ b/frontend/src/androidMain/kotlin/com/example/dashcam/service/AndroidSentryService.kt
@@ -1,0 +1,33 @@
+package com.example.dashcam.service
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.ContextCompat
+import com.example.dashcam.Event
+import com.example.dashcam.SentryService
+import com.example.dashcam.service.SentryMonitoringService
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Android implementation of [SentryService] that starts a foreground service
+ * for monitoring the camera feed using OpenCV or ML Kit.
+ */
+class AndroidSentryService(private val context: Context) : SentryService {
+    private val _isActive = MutableStateFlow(false)
+    override val isActive: StateFlow<Boolean> = _isActive
+
+    override val events: Flow<Event> = SentryMonitoringService.sharedEvents
+
+    override fun start() {
+        if (_isActive.value) return
+        _isActive.value = true
+        ContextCompat.startForegroundService(context, Intent(context, SentryMonitoringService::class.java))
+    }
+
+    override fun stop() {
+        _isActive.value = false
+        context.stopService(Intent(context, SentryMonitoringService::class.java))
+    }
+}

--- a/frontend/src/androidMain/kotlin/com/example/dashcam/service/SentryMonitoringService.kt
+++ b/frontend/src/androidMain/kotlin/com/example/dashcam/service/SentryMonitoringService.kt
@@ -1,0 +1,141 @@
+package com.example.dashcam.service
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import android.util.Log
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.ImageProxy
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+import com.example.dashcam.Event
+import com.example.dashcam.EventType
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import org.opencv.android.OpenCVLoader
+import org.opencv.core.Core
+import org.opencv.core.CvType
+import org.opencv.core.Mat
+import org.opencv.imgproc.Imgproc
+import java.util.concurrent.Executors
+
+/**
+ * Foreground service that would monitor the camera feed using an open source
+ * computer vision API such as OpenCV to detect motion or people. Detected
+ * events are emitted to [sharedEvents].
+ */
+class SentryMonitoringService : Service() {
+    private val scope = CoroutineScope(Dispatchers.Default)
+    private val executor = Executors.newSingleThreadExecutor()
+    private var cameraProvider: ProcessCameraProvider? = null
+    private var previous: Mat? = null
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        createChannel()
+        if (!OpenCVLoader.initDebug()) {
+            Log.e(TAG, "OpenCV init failed")
+            stopSelf()
+            return
+        }
+        val notification: Notification = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("Sentry Monitoring")
+            .setContentText("Monitoring vehicle")
+            .setSmallIcon(android.R.drawable.ic_menu_camera)
+            .build()
+        startForeground(1, notification)
+        startCamera()
+    }
+
+    private fun startCamera() {
+        val providerFuture = ProcessCameraProvider.getInstance(this)
+        providerFuture.addListener({
+            cameraProvider = providerFuture.get()
+            val analysis = ImageAnalysis.Builder()
+                .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+                .build()
+            analysis.setAnalyzer(executor, this::analyzeFrame)
+            try {
+                cameraProvider?.unbindAll()
+                cameraProvider?.bindToLifecycle(this, CameraSelector.DEFAULT_BACK_CAMERA, analysis)
+            } catch (e: Exception) {
+                Log.e(TAG, "Camera bind failed", e)
+            }
+        }, ContextCompat.getMainExecutor(this))
+    }
+
+    private fun analyzeFrame(proxy: ImageProxy) {
+        val mat = proxy.toMat()
+        val gray = Mat()
+        Imgproc.cvtColor(mat, gray, Imgproc.COLOR_RGBA2GRAY)
+        previous?.let { prev ->
+            val diff = Mat()
+            Core.absdiff(prev, gray, diff)
+            Imgproc.threshold(diff, diff, 30.0, 255.0, Imgproc.THRESH_BINARY)
+            val count = Core.countNonZero(diff)
+            if (count > MOTION_THRESHOLD) {
+                scope.launch { sharedEvents.emit(Event(EventType.Motion, "Motion detected")) }
+            }
+            diff.release()
+            prev.release()
+        }
+        previous = gray
+        mat.release()
+        proxy.close()
+    }
+
+    private fun ImageProxy.toMat(): Mat {
+        val yBuffer = planes[0].buffer
+        val uBuffer = planes[1].buffer
+        val vBuffer = planes[2].buffer
+
+        val ySize = yBuffer.remaining()
+        val uSize = uBuffer.remaining()
+        val vSize = vBuffer.remaining()
+
+        val nv21 = ByteArray(ySize + uSize + vSize)
+        yBuffer.get(nv21, 0, ySize)
+        vBuffer.get(nv21, ySize, vSize)
+        uBuffer.get(nv21, ySize + vSize, uSize)
+
+        val yuv = Mat(height + height / 2, width, CvType.CV_8UC1)
+        yuv.put(0, 0, nv21)
+
+        val rgba = Mat()
+        Imgproc.cvtColor(yuv, rgba, Imgproc.COLOR_YUV2RGBA_NV21, 4)
+        yuv.release()
+        return rgba
+    }
+
+    override fun onDestroy() {
+        cameraProvider?.unbindAll()
+        executor.shutdown()
+        previous?.release()
+        super.onDestroy()
+    }
+
+    private fun createChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(CHANNEL_ID, "Sentry", NotificationManager.IMPORTANCE_LOW)
+            val nm = getSystemService(NotificationManager::class.java)
+            nm.createNotificationChannel(channel)
+        }
+    }
+
+    companion object {
+        private const val CHANNEL_ID = "sentry_monitoring"
+        private const val MOTION_THRESHOLD = 5000
+        private const val TAG = "SentryService"
+        val sharedEvents = MutableSharedFlow<Event>()
+    }
+}

--- a/frontend/src/commonMain/kotlin/com/example/dashcam/App.kt
+++ b/frontend/src/commonMain/kotlin/com/example/dashcam/App.kt
@@ -14,6 +14,7 @@ fun DashcamApp(appViewModel: AppViewModel, dashcamViewModel: DashcamViewModel) {
             Screen.Onboarding -> OnboardingScreen(onDone = appViewModel::completeOnboarding)
             Screen.Login -> LoginScreen(onLogin = appViewModel::loginSuccess, onSignup = appViewModel::showSignup)
             Screen.Signup -> SignupScreen(onSignup = appViewModel::signupSuccess)
+            Screen.Permissions -> PermissionsScreen(onGrant = appViewModel::permissionsGranted)
             is Screen.Main -> MainScreen(s.tab, onSelectTab = appViewModel::selectTab, dashcamViewModel)
         }
     }

--- a/frontend/src/commonMain/kotlin/com/example/dashcam/ui/AppViewModel.kt
+++ b/frontend/src/commonMain/kotlin/com/example/dashcam/ui/AppViewModel.kt
@@ -9,8 +9,9 @@ class AppViewModel {
 
     fun completeOnboarding() { _screen.value = Screen.Login }
     fun showSignup() { _screen.value = Screen.Signup }
-    fun loginSuccess() { _screen.value = Screen.Main() }
-    fun signupSuccess() { _screen.value = Screen.Main() }
+    fun loginSuccess() { _screen.value = Screen.Permissions }
+    fun signupSuccess() { _screen.value = Screen.Permissions }
+    fun permissionsGranted() { _screen.value = Screen.Main() }
     fun selectTab(tab: MainTab) {
         val current = _screen.value
         if (current is Screen.Main) {

--- a/frontend/src/commonMain/kotlin/com/example/dashcam/ui/Screen.kt
+++ b/frontend/src/commonMain/kotlin/com/example/dashcam/ui/Screen.kt
@@ -4,6 +4,8 @@ sealed class Screen {
     object Onboarding : Screen()
     object Login : Screen()
     object Signup : Screen()
+    /** Screen shown to request platform permissions before entering the app. */
+    object Permissions : Screen()
     data class Main(val tab: MainTab = MainTab.Dashcam) : Screen()
 }
 

--- a/frontend/src/commonMain/kotlin/com/example/dashcam/ui/screens/PermissionsScreen.kt
+++ b/frontend/src/commonMain/kotlin/com/example/dashcam/ui/screens/PermissionsScreen.kt
@@ -1,0 +1,27 @@
+package com.example.dashcam.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * Intermediate screen asking the user to grant camera and notification permissions.
+ */
+@Composable
+fun PermissionsScreen(onGrant: () -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(16.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text("Permissions required")
+        Spacer(Modifier.height(8.dp))
+        Text("Camera and notification access is needed for sentry mode")
+        Spacer(Modifier.height(16.dp))
+        Button(onClick = onGrant) { Text("Grant Permissions") }
+    }
+}

--- a/frontend/src/jvmTest/kotlin/com/example/dashcam/ui/screens/PermissionsScreenTest.kt
+++ b/frontend/src/jvmTest/kotlin/com/example/dashcam/ui/screens/PermissionsScreenTest.kt
@@ -1,0 +1,19 @@
+package com.example.dashcam.ui.screens
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+class PermissionsScreenTest : BehaviorSpec({
+    val rule = createComposeRule()
+    Given("the permissions screen") {
+        var granted = false
+        rule.setContent { PermissionsScreen { granted = true } }
+        When("the grant button is tapped") {
+            rule.onNodeWithText("Grant Permissions").performClick()
+            Then("callback fires") { granted shouldBe true }
+        }
+    }
+})


### PR DESCRIPTION
## Summary
- add a new intermediate `PermissionsScreen`
- route login/signup success to the permissions screen
- handle permission completion before showing the main screen
- implement Android foreground `SentryMonitoringService` using OpenCV
- expose `AndroidSentryService`
- support Android build and open source CV libs
- add unit test for the permissions screen
- implement basic motion detection from the camera feed

## Testing
- `gradle test --no-daemon` *(fails: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_68469e3a10b4832f939d6c9ca80a183c