### PR TITLE
Improve dashcam permission flow

### DIFF
--- a/frontend/src/androidMain/kotlin/com/example/dashcam/camera/CameraPreview.android.kt
+++ b/frontend/src/androidMain/kotlin/com/example/dashcam/camera/CameraPreview.android.kt
@@ -1,0 +1,84 @@
+package com.example.dashcam.camera
+
+import android.Manifest
+import android.content.pm.PackageManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.Preview
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.PreviewView
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.content.ContextCompat
+
+@Composable
+actual fun CameraPreview(modifier: Modifier) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val previewView = remember { PreviewView(context) }
+
+    AndroidView(factory = { previewView }, modifier = modifier)
+
+    DisposableEffect(lifecycleOwner) {
+        val cameraProviderFuture = ProcessCameraProvider.getInstance(context)
+        val executor = ContextCompat.getMainExecutor(context)
+        cameraProviderFuture.addListener({
+            val cameraProvider = cameraProviderFuture.get()
+            val preview = Preview.Builder().build().also {
+                it.setSurfaceProvider(previewView.surfaceProvider)
+            }
+            try {
+                cameraProvider.unbindAll()
+                cameraProvider.bindToLifecycle(lifecycleOwner, CameraSelector.DEFAULT_BACK_CAMERA, preview)
+            } catch (_: Exception) {
+            }
+        }, executor)
+        onDispose {
+            try {
+                cameraProviderFuture.get().unbindAll()
+            } catch (_: Exception) {}
+        }
+    }
+}
+
+@Composable
+actual fun ensureCameraPermission(): Boolean {
+    val context = LocalContext.current
+    var granted by remember {
+        mutableStateOf(
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.CAMERA
+            ) == PackageManager.PERMISSION_GRANTED
+        )
+    }
+    val launcher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
+        granted = it
+    }
+
+    LaunchedEffect(Unit) {
+        if (!granted) {
+            launcher.launch(Manifest.permission.CAMERA)
+        }
+    }
+    return granted
+}
+
+@Composable
+actual fun isCameraPermissionGranted(): Boolean {
+    val context = LocalContext.current
+    return ContextCompat.checkSelfPermission(
+        context,
+        Manifest.permission.CAMERA
+    ) == PackageManager.PERMISSION_GRANTED
+}

--- a/frontend/src/commonMain/kotlin/com/example/dashcam/App.kt
+++ b/frontend/src/commonMain/kotlin/com/example/dashcam/App.kt
@@ -1,21 +1,26 @@
 package com.example.dashcam
 
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import com.example.dashcam.ui.*
 import com.example.dashcam.ui.screens.*
+import com.example.dashcam.ui.theme.DashcamTheme
 
 @Composable
 fun DashcamApp(appViewModel: AppViewModel, dashcamViewModel: DashcamViewModel) {
     val screen = appViewModel.screen.collectAsState()
-    MaterialTheme {
+    DashcamTheme {
         when(val s = screen.value) {
             Screen.Onboarding -> OnboardingScreen(onDone = appViewModel::completeOnboarding)
             Screen.Login -> LoginScreen(onLogin = appViewModel::loginSuccess, onSignup = appViewModel::showSignup)
             Screen.Signup -> SignupScreen(onSignup = appViewModel::signupSuccess)
             Screen.Permissions -> PermissionsScreen(onGrant = appViewModel::permissionsGranted)
-            is Screen.Main -> MainScreen(s.tab, onSelectTab = appViewModel::selectTab, dashcamViewModel)
+            is Screen.Main -> MainScreen(
+                s.tab,
+                onSelectTab = appViewModel::selectTab,
+                dashcamViewModel = dashcamViewModel,
+                onPermissionsRequired = appViewModel::requestPermissions
+            )
         }
     }
 }

--- a/frontend/src/commonMain/kotlin/com/example/dashcam/camera/CameraPreview.kt
+++ b/frontend/src/commonMain/kotlin/com/example/dashcam/camera/CameraPreview.kt
@@ -1,0 +1,22 @@
+package com.example.dashcam.camera
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ * Platform specific camera preview composable.
+ */
+@Composable
+expect fun CameraPreview(modifier: Modifier = Modifier)
+
+/**
+ * Ensures camera permission is granted. Returns true if the permission is available.
+ */
+@Composable
+expect fun ensureCameraPermission(): Boolean
+
+/**
+ * Returns true if the camera permission is currently granted.
+ */
+@Composable
+expect fun isCameraPermissionGranted(): Boolean

--- a/frontend/src/commonMain/kotlin/com/example/dashcam/ui/AppViewModel.kt
+++ b/frontend/src/commonMain/kotlin/com/example/dashcam/ui/AppViewModel.kt
@@ -12,6 +12,7 @@ class AppViewModel {
     fun loginSuccess() { _screen.value = Screen.Permissions }
     fun signupSuccess() { _screen.value = Screen.Permissions }
     fun permissionsGranted() { _screen.value = Screen.Main() }
+    fun requestPermissions() { _screen.value = Screen.Permissions }
     fun selectTab(tab: MainTab) {
         val current = _screen.value
         if (current is Screen.Main) {

--- a/frontend/src/commonMain/kotlin/com/example/dashcam/ui/screens/DashcamScreen.kt
+++ b/frontend/src/commonMain/kotlin/com/example/dashcam/ui/screens/DashcamScreen.kt
@@ -1,12 +1,20 @@
 package com.example.dashcam.ui.screens
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FiberManualRecord
+import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -17,26 +25,59 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.runtime.LaunchedEffect
+import com.example.dashcam.camera.CameraPreview
+import com.example.dashcam.camera.isCameraPermissionGranted
 
 /**
  * Simple dashcam screen that mocks a recording session.
  */
 @Preview
 @Composable
-fun DashcamScreen() {
+fun DashcamScreen(onMissingPermissions: () -> Unit = {}) {
     var recording by remember { mutableStateOf(false) }
+    val hasPermission = isCameraPermissionGranted()
 
-    Column(
-        modifier = Modifier.fillMaxSize().padding(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Text(
-            if (recording) "Recording..." else "Ready to record",
-            style = MaterialTheme.typography.headlineMedium
-        )
-        Spacer(Modifier.height(16.dp))
-        Button(onClick = { recording = !recording }) {
-            Text(if (recording) "Stop" else "Start")
+    LaunchedEffect(hasPermission) {
+        if (!hasPermission) onMissingPermissions()
+    }
+
+    Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
+        if (hasPermission) {
+            CameraPreview(Modifier.fillMaxSize())
+        } else {
+            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text("Camera permission required", color = MaterialTheme.colorScheme.onBackground)
+            }
+        }
+
+        Column(
+            modifier = Modifier.fillMaxSize().padding(16.dp),
+            verticalArrangement = Arrangement.SpaceBetween
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                if (recording) {
+                    Icon(Icons.Default.FiberManualRecord, contentDescription = null, tint = MaterialTheme.colorScheme.error)
+                    Spacer(Modifier.width(4.dp))
+                    Text("REC", color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodyLarge)
+                } else {
+                    Text("Ready", color = MaterialTheme.colorScheme.onBackground, style = MaterialTheme.typography.bodyLarge)
+                }
+            }
+
+            Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                FloatingActionButton(
+                    onClick = { recording = !recording },
+                    containerColor = if (recording) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary,
+                    enabled = hasPermission
+                ) {
+                    Icon(
+                        imageVector = if (recording) Icons.Default.Stop else Icons.Default.FiberManualRecord,
+                        contentDescription = if (recording) "Stop recording" else "Start recording"
+                    )
+                }
+            }
         }
     }
 }

--- a/frontend/src/commonMain/kotlin/com/example/dashcam/ui/screens/MainScreen.kt
+++ b/frontend/src/commonMain/kotlin/com/example/dashcam/ui/screens/MainScreen.kt
@@ -19,7 +19,12 @@ import com.example.dashcam.DashcamViewModel
 import com.example.dashcam.ui.MainTab
 @Preview
 @Composable
-fun MainScreen(tab: MainTab, onSelectTab: (MainTab) -> Unit, dashcamViewModel: DashcamViewModel) {
+fun MainScreen(
+    tab: MainTab,
+    onSelectTab: (MainTab) -> Unit,
+    dashcamViewModel: DashcamViewModel,
+    onPermissionsRequired: () -> Unit,
+) {
     Scaffold(bottomBar = {
         NavigationBar {
             NavigationBarItem(
@@ -50,7 +55,7 @@ fun MainScreen(tab: MainTab, onSelectTab: (MainTab) -> Unit, dashcamViewModel: D
     }) { inner ->
         Box(Modifier.fillMaxSize().padding(inner)) {
             when (tab) {
-                MainTab.Dashcam -> DashcamScreen()
+                MainTab.Dashcam -> DashcamScreen(onMissingPermissions = onPermissionsRequired)
                 MainTab.Sentry -> SentryScreen(dashcamViewModel)
                 MainTab.History -> HistoryScreen(dashcamViewModel)
                 MainTab.Settings -> SettingsScreen()

--- a/frontend/src/commonMain/kotlin/com/example/dashcam/ui/screens/PermissionsScreen.kt
+++ b/frontend/src/commonMain/kotlin/com/example/dashcam/ui/screens/PermissionsScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import com.example.dashcam.camera.ensureCameraPermission
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -21,8 +22,10 @@ fun PermissionsScreen(onGrant: () -> Unit) {
     ) {
         Text("Permissions required")
         Spacer(Modifier.height(8.dp))
-        Text("Camera and notification access is needed for sentry mode")
+        Text("Camera access lets the app record video while notifications keep you informed of events. Grant these to continue.")
         Spacer(Modifier.height(16.dp))
-        Button(onClick = onGrant) { Text("Grant Permissions") }
+        Button(onClick = { if (ensureCameraPermission()) onGrant() }) {
+            Text("Grant Permissions")
+        }
     }
 }

--- a/frontend/src/commonMain/kotlin/com/example/dashcam/ui/theme/DashcamTheme.kt
+++ b/frontend/src/commonMain/kotlin/com/example/dashcam/ui/theme/DashcamTheme.kt
@@ -1,0 +1,27 @@
+package com.example.dashcam.ui.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+
+private val DashcamColors = darkColorScheme(
+    primary = Color(0xFF2196F3),
+    secondary = Color(0xFF03DAC5),
+    background = Color.Black,
+    surface = Color(0xFF121212),
+    onPrimary = Color.Black,
+    onSecondary = Color.Black,
+    onBackground = Color.White,
+    onSurface = Color.White,
+    error = Color(0xFFEF5350)
+)
+
+@Composable
+fun DashcamTheme(content: @Composable () -> Unit) {
+    MaterialTheme(
+        colorScheme = DashcamColors,
+        typography = MaterialTheme.typography,
+        content = content
+    )
+}

--- a/frontend/src/commonTest/kotlin/com/example/dashcam/ui/AppViewModelTest.kt
+++ b/frontend/src/commonTest/kotlin/com/example/dashcam/ui/AppViewModelTest.kt
@@ -14,17 +14,19 @@ class AppViewModelTest : BehaviorSpec({
         }
         When("login succeeds") {
             vm.loginSuccess()
-            Then("main screen is shown with dashcam tab") {
-                vm.screen.value shouldBe Screen.Main()
+            Then("permissions screen is shown") {
+                vm.screen.value shouldBe Screen.Permissions
             }
         }
         When("selecting history tab") {
+            vm.permissionsGranted()
             vm.selectTab(MainTab.History)
             Then("history tab is active") {
                 vm.screen.value shouldBe Screen.Main(MainTab.History)
             }
         }
         When("selecting settings tab") {
+            vm.permissionsGranted()
             vm.selectTab(MainTab.Settings)
             Then("settings tab is active") {
                 vm.screen.value shouldBe Screen.Main(MainTab.Settings)

--- a/frontend/src/jvmMain/kotlin/com/example/dashcam/camera/CameraPreview.jvm.kt
+++ b/frontend/src/jvmMain/kotlin/com/example/dashcam/camera/CameraPreview.jvm.kt
@@ -1,0 +1,18 @@
+package com.example.dashcam.camera
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+
+@Composable
+actual fun CameraPreview(modifier: Modifier) {
+    Box(modifier = modifier.background(Color.Black))
+}
+
+@Composable
+actual fun ensureCameraPermission(): Boolean = true
+
+@Composable
+actual fun isCameraPermissionGranted(): Boolean = true


### PR DESCRIPTION
## Summary
- require permissions from a dedicated screen
- add `isCameraPermissionGranted` expect/actual functions
- navigate to PermissionsScreen when dashcam lacks permission
- update AppViewModel and tests for new workflow
- update PermissionsScreen text

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849fed83824832f88544d3510ea9680