### PR TITLE
Improve history feed UX

### DIFF
--- a/frontend/src/androidMain/kotlin/com/example/dashcam/service/SentryMonitoringService.kt
+++ b/frontend/src/androidMain/kotlin/com/example/dashcam/service/SentryMonitoringService.kt
@@ -83,7 +83,15 @@ class SentryMonitoringService : LifecycleService() {
             Imgproc.threshold(diff, diff, 30.0, 255.0, Imgproc.THRESH_BINARY)
             val count = Core.countNonZero(diff)
             if (count > MOTION_THRESHOLD) {
-                scope.launch { sharedEvents.emit(Event(EventType.Motion, "Motion detected")) }
+                scope.launch {
+                    sharedEvents.emit(
+                        Event(
+                            EventType.Motion,
+                            "Motion detected",
+                            timestamp = System.currentTimeMillis(),
+                        )
+                    )
+                }
             }
             diff.release()
             prev.release()

--- a/frontend/src/commonMain/kotlin/com/example/dashcam/App.kt
+++ b/frontend/src/commonMain/kotlin/com/example/dashcam/App.kt
@@ -19,8 +19,10 @@ fun DashcamApp(appViewModel: AppViewModel, dashcamViewModel: DashcamViewModel) {
                 s.tab,
                 onSelectTab = appViewModel::selectTab,
                 dashcamViewModel = dashcamViewModel,
-                onPermissionsRequired = appViewModel::requestPermissions
+                onPermissionsRequired = appViewModel::requestPermissions,
+                onEventSelected = appViewModel::showEvent,
             )
+            is Screen.EventDetail -> EventDetailsScreen(event = s.event, onBack = appViewModel::closeEvent)
         }
     }
 }

--- a/frontend/src/commonMain/kotlin/com/example/dashcam/Event.kt
+++ b/frontend/src/commonMain/kotlin/com/example/dashcam/Event.kt
@@ -10,10 +10,12 @@ enum class EventType { Motion, Person, Vehicle, Collision, Audio }
  * @param description user friendly message
  * @param timestamp when the event occurred in epoch millis
  * @param screenshotPath optional path to a captured screenshot
+ * @param videoPath optional path to the recorded video clip
  */
 data class Event(
     val type: EventType,
     val description: String,
     val timestamp: Long,
     val screenshotPath: String? = null,
+    val videoPath: String? = null,
 )

--- a/frontend/src/commonMain/kotlin/com/example/dashcam/Event.kt
+++ b/frontend/src/commonMain/kotlin/com/example/dashcam/Event.kt
@@ -4,7 +4,16 @@ package com.example.dashcam
 enum class EventType { Motion, Person, Vehicle, Collision, Audio }
 
 /**
- * Representation of a sentry event. The [type] describes what was detected and
- * [description] provides a user friendly message.
+ * Representation of a sentry event.
+ *
+ * @param type what was detected
+ * @param description user friendly message
+ * @param timestamp when the event occurred in epoch millis
+ * @param screenshotPath optional path to a captured screenshot
  */
-data class Event(val type: EventType, val description: String)
+data class Event(
+    val type: EventType,
+    val description: String,
+    val timestamp: Long,
+    val screenshotPath: String? = null,
+)

--- a/frontend/src/commonMain/kotlin/com/example/dashcam/EventService.kt
+++ b/frontend/src/commonMain/kotlin/com/example/dashcam/EventService.kt
@@ -10,11 +10,15 @@ class LocalEventService : EventService {
             EventType.Motion,
             "Motion detected",
             timestamp = System.currentTimeMillis() - 3_600_000,
+            screenshotPath = null,
+            videoPath = null,
         ),
         Event(
             EventType.Person,
             "Camera started",
             timestamp = System.currentTimeMillis() - 7_200_000,
+            screenshotPath = null,
+            videoPath = null,
         )
     )
 }

--- a/frontend/src/commonMain/kotlin/com/example/dashcam/EventService.kt
+++ b/frontend/src/commonMain/kotlin/com/example/dashcam/EventService.kt
@@ -6,7 +6,15 @@ interface EventService {
 
 class LocalEventService : EventService {
     override fun getEvents(): List<Event> = listOf(
-        Event(EventType.Motion, "Motion detected"),
-        Event(EventType.Person, "Camera started")
+        Event(
+            EventType.Motion,
+            "Motion detected",
+            timestamp = System.currentTimeMillis() - 3_600_000,
+        ),
+        Event(
+            EventType.Person,
+            "Camera started",
+            timestamp = System.currentTimeMillis() - 7_200_000,
+        )
     )
 }

--- a/frontend/src/commonMain/kotlin/com/example/dashcam/Settings.kt
+++ b/frontend/src/commonMain/kotlin/com/example/dashcam/Settings.kt
@@ -1,0 +1,22 @@
+package com.example.dashcam
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/** App-wide settings. */
+object Settings {
+    private val _videoDurationSec = MutableStateFlow(6)
+    /** Duration of recorded event clips in seconds. */
+    val videoDurationSec: StateFlow<Int> = _videoDurationSec
+
+    /**
+     * Update desired recording length. Duration is clamped to [MIN_DURATION]..[MAX_DURATION].
+     */
+    fun setVideoDuration(seconds: Int) {
+        val clamped = seconds.coerceIn(MIN_DURATION, MAX_DURATION)
+        _videoDurationSec.value = clamped
+    }
+
+    const val MIN_DURATION = 6
+    const val MAX_DURATION = 300
+}

--- a/frontend/src/commonMain/kotlin/com/example/dashcam/ui/AppViewModel.kt
+++ b/frontend/src/commonMain/kotlin/com/example/dashcam/ui/AppViewModel.kt
@@ -19,4 +19,12 @@ class AppViewModel {
             _screen.value = current.copy(tab = tab)
         }
     }
+
+    fun showEvent(event: com.example.dashcam.Event) {
+        _screen.value = Screen.EventDetail(event)
+    }
+
+    fun closeEvent() {
+        _screen.value = Screen.Main(MainTab.History)
+    }
 }

--- a/frontend/src/commonMain/kotlin/com/example/dashcam/ui/Screen.kt
+++ b/frontend/src/commonMain/kotlin/com/example/dashcam/ui/Screen.kt
@@ -7,6 +7,7 @@ sealed class Screen {
     /** Screen shown to request platform permissions before entering the app. */
     object Permissions : Screen()
     data class Main(val tab: MainTab = MainTab.Dashcam) : Screen()
+    data class EventDetail(val event: com.example.dashcam.Event) : Screen()
 }
 
 enum class MainTab { Dashcam, Sentry, History, Settings }

--- a/frontend/src/commonMain/kotlin/com/example/dashcam/ui/screens/EventDetailsScreen.kt
+++ b/frontend/src/commonMain/kotlin/com/example/dashcam/ui/screens/EventDetailsScreen.kt
@@ -1,0 +1,63 @@
+package com.example.dashcam.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.example.dashcam.Event
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+private val detailFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EventDetailsScreen(event: Event, onBack: () -> Unit) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Event Details") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { inner ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(inner)
+                .padding(16.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(200.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    Icons.Default.Image,
+                    contentDescription = null,
+                    modifier = Modifier.size(96.dp),
+                    tint = Color.Gray
+                )
+            }
+            Spacer(Modifier.height(16.dp))
+            Text(event.description, style = MaterialTheme.typography.headlineSmall)
+            Spacer(Modifier.height(8.dp))
+            Text(
+                detailFormatter.format(Instant.ofEpochMilli(event.timestamp).atZone(ZoneId.systemDefault())),
+                style = MaterialTheme.typography.bodyMedium
+            )
+        }
+    }
+}

--- a/frontend/src/commonMain/kotlin/com/example/dashcam/ui/screens/HistoryScreen.kt
+++ b/frontend/src/commonMain/kotlin/com/example/dashcam/ui/screens/HistoryScreen.kt
@@ -1,24 +1,60 @@
 package com.example.dashcam.ui.screens
 
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.Card
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.example.dashcam.DashcamViewModel
+import com.example.dashcam.Event
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
 
 @Composable
-fun HistoryScreen(viewModel: DashcamViewModel) {
+fun HistoryScreen(
+    viewModel: DashcamViewModel,
+    onEventSelected: (Event) -> Unit = {},
+) {
     val events = viewModel.events.collectAsState()
     LazyColumn(modifier = Modifier.padding(16.dp)) {
-        items(events.value) { event ->
-            Card(modifier = Modifier.padding(vertical = 4.dp)) {
-                Text(event.description, style = MaterialTheme.typography.bodyLarge, modifier = Modifier.padding(16.dp))
+        items(events.value.sortedByDescending { it.timestamp }) { event ->
+            Card(
+                modifier = Modifier
+                    .padding(vertical = 4.dp)
+                    .fillMaxWidth()
+                    .clickable { onEventSelected(event) },
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.padding(16.dp)
+                ) {
+                    Icon(
+                        Icons.Default.Image,
+                        contentDescription = null,
+                        tint = Color.Gray,
+                        modifier = Modifier.size(48.dp)
+                    )
+                    Spacer(Modifier.width(12.dp))
+                    Column {
+                        Text(event.description, style = MaterialTheme.typography.bodyLarge)
+                        Text(
+                            formatter.format(Instant.ofEpochMilli(event.timestamp).atZone(ZoneId.systemDefault())),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = Color.Gray,
+                        )
+                    }
+                }
             }
         }
     }

--- a/frontend/src/commonMain/kotlin/com/example/dashcam/ui/screens/MainScreen.kt
+++ b/frontend/src/commonMain/kotlin/com/example/dashcam/ui/screens/MainScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.example.dashcam.DashcamViewModel
 import com.example.dashcam.ui.MainTab
+import com.example.dashcam.Event
 
 @Composable
 fun MainScreen(
@@ -24,6 +25,7 @@ fun MainScreen(
     onSelectTab: (MainTab) -> Unit,
     dashcamViewModel: DashcamViewModel,
     onPermissionsRequired: () -> Unit,
+    onEventSelected: (Event) -> Unit = {},
 ) {
     Scaffold(bottomBar = {
         NavigationBar {
@@ -57,7 +59,7 @@ fun MainScreen(
             when (tab) {
                 MainTab.Dashcam -> DashcamScreen(onMissingPermissions = onPermissionsRequired)
                 MainTab.Sentry -> SentryScreen(dashcamViewModel)
-                MainTab.History -> HistoryScreen(dashcamViewModel)
+                MainTab.History -> HistoryScreen(dashcamViewModel, onEventSelected)
                 MainTab.Settings -> SettingsScreen()
             }
         }

--- a/frontend/src/commonMain/kotlin/com/example/dashcam/ui/screens/SettingsScreen.kt
+++ b/frontend/src/commonMain/kotlin/com/example/dashcam/ui/screens/SettingsScreen.kt
@@ -1,26 +1,40 @@
 package com.example.dashcam.ui.screens
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Slider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.example.dashcam.Settings
+import kotlin.math.roundToInt
 
 @Composable
 fun SettingsScreen() {
-    Row(
-        modifier = Modifier.fillMaxSize().padding(16.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Text("Dark Mode", style = MaterialTheme.typography.bodyLarge)
-        Spacer(Modifier.width(8.dp))
-        Switch(checked = false, onCheckedChange = {})
+    val duration = Settings.videoDurationSec.collectAsState()
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text("Dark Mode", style = MaterialTheme.typography.bodyLarge)
+            Spacer(Modifier.width(8.dp))
+            Switch(checked = false, onCheckedChange = {})
+        }
+        Spacer(Modifier.height(32.dp))
+        Text("Clip Length", style = MaterialTheme.typography.bodyLarge)
+        Text("${duration.value}s", style = MaterialTheme.typography.bodyMedium)
+        Slider(
+            value = duration.value.toFloat(),
+            onValueChange = { Settings.setVideoDuration(it.roundToInt()) },
+            valueRange = Settings.MIN_DURATION.toFloat()..Settings.MAX_DURATION.toFloat(),
+        )
     }
 }

--- a/frontend/src/jvmMain/kotlin/com/example/dashcam/service/MockSentryService.kt
+++ b/frontend/src/jvmMain/kotlin/com/example/dashcam/service/MockSentryService.kt
@@ -47,6 +47,8 @@ class MockSentryService : SentryService {
                         type = type,
                         description = desc,
                         timestamp = System.currentTimeMillis(),
+                        screenshotPath = null,
+                        videoPath = null,
                     )
                 )
             }

--- a/frontend/src/jvmMain/kotlin/com/example/dashcam/service/MockSentryService.kt
+++ b/frontend/src/jvmMain/kotlin/com/example/dashcam/service/MockSentryService.kt
@@ -42,7 +42,13 @@ class MockSentryService : SentryService {
                     EventType.Collision -> "Possible collision"
                     EventType.Audio -> "Excessive audio detected"
                 }
-                _events.emit(Event(type, desc))
+                _events.emit(
+                    Event(
+                        type = type,
+                        description = desc,
+                        timestamp = System.currentTimeMillis(),
+                    )
+                )
             }
         }
     }

--- a/frontend/src/jvmTest/kotlin/com/example/dashcam/ui/screens/SettingsScreenTest.kt
+++ b/frontend/src/jvmTest/kotlin/com/example/dashcam/ui/screens/SettingsScreenTest.kt
@@ -11,5 +11,8 @@ class SettingsScreenTest : BehaviorSpec({
         Then("the dark mode option is shown") {
             rule.onNodeWithText("Dark Mode").assertExists()
         }
+        Then("the clip length slider is shown") {
+            rule.onNodeWithText("Clip Length").assertExists()
+        }
     }
 })


### PR DESCRIPTION
## Summary
- add timestamp and screenshot info to `Event`
- return sample events with timestamps
- include timestamp when services emit events
- sort events newest first in `HistoryScreen`
- allow opening `EventDetailsScreen`
- add navigation for event details

## Testing
- `gradle :frontend:jvmTest`

------
https://chatgpt.com/codex/tasks/task_e_684b456d7f80832f8000b5d911f04763